### PR TITLE
Fix `rx` and `ry` element problems

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -222,6 +222,7 @@ class PaperCanvas extends React.Component {
         // the viewBox to start at (0, 0), and we need to translate it back for some costumes to render
         // correctly.
         const parser = new DOMParser();
+        const serializer = new XMLSerializer();
         const svgDom = parser.parseFromString(svg, 'text/xml');
         const viewBox = svgDom.documentElement.attributes.viewBox ?
             svgDom.documentElement.attributes.viewBox.value.match(/\S+/g) : null;
@@ -231,7 +232,28 @@ class PaperCanvas extends React.Component {
             }
         }
 
-        paper.project.importSVG(svg, {
+        // TW: paper.js for some reason ignores rx or ry values if it's missing the other.
+        svgDom.querySelectorAll('[rx], [ry]').forEach(element => {
+            if (
+                element.hasAttribute('rx') &&
+                !element.hasAttribute('ry')
+            ) {
+                element.setAttribute(
+                    element.getAttribute('rx'),
+                    'ry'
+                );
+            } else if (
+                !element.hasAttribute('rx') &&
+                element.hasAttribute('ry')
+            ) {
+                element.setAttribute(
+                    'rx',
+                    element.getAttribute('ry')
+                );
+            }
+        });
+
+        paper.project.importSVG(serializer.serializeToString(svgDom), {
             expandShapes: true,
             insert: false,
             onLoad: function (item) {


### PR DESCRIPTION
Currently, paper.js ignores lone `rx` or `ry` elements in an SVG, causing it to fail to render properly in the paint editor.

This PR checks the SVG for the existence of either element and the non existence of the other respectively, and adds it.

Currently known SVG makers that have the problem of only exporting with one of the aforementioned elements are Figma and Adobe XD.

Example SVG to test:
![Rectangle 1](https://github.com/user-attachments/assets/95fa8ce1-fa49-4dc3-9799-d1549599feda)